### PR TITLE
update babel.config.js to work with latest versions of webpack node modules

### DIFF
--- a/lib/install/config/babel.config.js
+++ b/lib/install/config/babel.config.js
@@ -42,27 +42,12 @@ module.exports = function(api) {
       isTestEnv && 'babel-plugin-dynamic-import-node',
       '@babel/plugin-transform-destructuring',
       [
-        '@babel/plugin-proposal-class-properties',
-        {
-          loose: true
-        }
+        '@babel/plugin-proposal-class-properties'
       ],
       [
         '@babel/plugin-proposal-object-rest-spread',
         {
           useBuiltIns: true
-        }
-      ],
-      [
-        '@babel/plugin-proposal-private-methods',
-        {
-          loose: true
-        }
-      ],
-      [
-        '@babel/plugin-proposal-private-property-in-object',
-        {
-          loose: true
         }
       ],
       [


### PR DESCRIPTION
Using jets version 4.0.1, though the issue not related to the jets version. It's a node version with babel and the babel.config.js that `jets webpacker:install` installs issue. Believe babel updated the interface and the babel.config.js needs to be updated to reflect that.  

To reproduce:

    jets new demo
    cd demo
    bin/webpack

Details:

    $ bin/webpack
    node:internal/process/promises:279
                triggerUncaughtException(err, true /* fromPromise */);
                ^

    Error: Cannot find package '@babel/plugin-proposal-private-methods' imported from ~/demo/babel-virtual-resolve-base.js
        at new NodeError (~/demo/node_modules/@babel/core/lib/vendor/import-meta-resolve.js:203:5)
        at packageResolve (~/demo/node_modules/@babel/core/lib/vendor/import-meta-resolve.js:873:9)
        at moduleResolve (~/demo/node_modules/@babel/core/lib/vendor/import-meta-resolve.js:902:20)
        at defaultResolve (~/demo/node_modules/@babel/core/lib/vendor/import-meta-resolve.js:985:15)
        at resolve (~/demo/node_modules/@babel/core/lib/vendor/import-meta-resolve.js:999:12)
        at resolve (~/demo/node_modules/@babel/core/lib/config/files/import-meta-resolve.js:13:10)
        at tryImportMetaResolve (~/demo/node_modules/@babel/core/lib/config/files/plugins.js:137:45)
        at resolveStandardizedNameForImport (~/demo/node_modules/@babel/core/lib/config/files/plugins.js:159:19)
        at resolveStandardizedName (~/demo/node_modules/@babel/core/lib/config/files/plugins.js:168:12)
        at loadPlugin (~/demo/node_modules/@babel/core/lib/config/files/plugins.js:47:20)
        at loadPlugin.next (<anonymous>)
        at createDescriptor (~/demo/node_modules/@babel/core/lib/config/config-descriptors.js:139:16)
        at createDescriptor.next (<anonymous>)
        at step (~/demo/node_modules/gensync/index.js:261:32)
        at evaluateAsync (~/demo/node_modules/gensync/index.js:291:5)
        at ~/demo/node_modules/gensync/index.js:44:11
        at Array.forEach (<anonymous>)
        at Function.async (~/demo/node_modules/gensync/index.js:43:15)
        at Function.all (~/demo/node_modules/gensync/index.js:216:13)
        at Generator.next (<anonymous>)
        at createDescriptors (~/demo/node_modules/@babel/core/lib/config/config-descriptors.js:101:41)
        at createDescriptors.next (<anonymous>)
        at createPluginDescriptors (~/demo/node_modules/@babel/core/lib/config/config-descriptors.js:98:17)
        at createPluginDescriptors.next (<anonymous>)
        at ~/demo/node_modules/@babel/core/lib/gensync-utils/functional.js:21:23
        at Generator.next (<anonymous>)
        at mergeChainOpts (~/demo/node_modules/@babel/core/lib/config/config-chain.js:347:34)
        at mergeChainOpts.next (<anonymous>)
        at chainWalker (~/demo/node_modules/@babel/core/lib/config/config-chain.js:314:14)
        at chainWalker.next (<anonymous>) {
      code: 'ERR_MODULE_NOT_FOUND'
    }

Related https://community.boltops.com/t/bin-webpack-error-cannot-find-package-babel-plugin-proposal-private-methods/1074

